### PR TITLE
feat: allow custom salt size for PBKDF2 key derivation

### DIFF
--- a/key.go
+++ b/key.go
@@ -7,7 +7,7 @@ type KeyGenerator interface {
 	// Generate returns a derived key from a password and a salt.
 	Generate(password string, salt ...byte) (derivedKey string, err error)
 	// GenerateSalt returns a random salt.
-	GenerateSalt() (salt []byte, err error)
+	GenerateSalt(size ...int) (salt []byte, err error)
 	// Compare compares if derived key is equal to the password.
 	Compare(derivedKey, password string, salt []byte) bool
 }

--- a/pbkdf2.go
+++ b/pbkdf2.go
@@ -65,8 +65,13 @@ func (p *PBKDF2) Compare(derivedKey, password string, salt []byte) bool {
 	return dk == derivedKey
 }
 
-func (p *PBKDF2) GenerateSalt() (salt []byte, err error) {
-	saltSize := 16
+const DEFAULT_SALT_SIZE = 16
+
+func (p *PBKDF2) GenerateSalt(size ...int) (salt []byte, err error) {
+	saltSize := DEFAULT_SALT_SIZE
+	if len(size) > 0 {
+		saltSize = size[0]
+	}
 	salt = make([]byte, saltSize)
 	_, err = rand.Read(salt)
 	return

--- a/pbkdf2_test.go
+++ b/pbkdf2_test.go
@@ -24,7 +24,7 @@ func TestPBKDF2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(derivedKey), keyLength * 2)
 	assert.True(t, keyGenerator.Compare(derivedKey, password, salt))
-	salt, err = keyGenerator.GenerateSalt()
+	salt, err = keyGenerator.GenerateSalt(32)
 	assert.NoError(t, err)
 	secondDerivedKey, err := keyGenerator.Generate(password, salt...)
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR modifies the `GenerateSalt` method in the `KeyGenerator` interface and the `PBKDF2` implementation to allow specifying a custom salt size.

The changes include:

- Modified `KeyGenerator` interface to accept an optional size parameter in the `GenerateSalt` method.
- Modified `PBKDF2` implementation to accept an optional size parameter in the `GenerateSalt` method, defaulting to 16 if no size is provided.
- Updated the `pbkdf2_test.go` to pass a salt size of 32 to the `GenerateSalt` method.